### PR TITLE
Initialize dot reduction value and default copy+move ops

### DIFF
--- a/cg-solve/cgsolve_omp.cpp
+++ b/cg-solve/cgsolve_omp.cpp
@@ -84,7 +84,7 @@ void spmv(YType y, AType A, XType x) {
 
 template <class YType, class XType>
 double dot(YType y, XType x) {
-  double result;
+  double result = 0.0;
   const size_t n = y.extent(0);
 
   #pragma omp parallel for reduction(+:result)

--- a/cg-solve/generate_matrix.hpp
+++ b/cg-solve/generate_matrix.hpp
@@ -62,6 +62,11 @@ namespace Kokkos {
 
             }
 
+            View(View const&) noexcept = default;
+            View(View&&) noexcept = default;
+            View& operator=(View const&) noexcept = default;
+            View& operator=(View&&) noexcept = default;
+
             ~View() {
                 /* delete m_array; */
             }


### PR DESCRIPTION
I discovered the bug by compiling with warnings (`-Wall -Wextra`).
Additionally, it's good practice to define copy/move assignment/constructors if you have a custom-defined destructor. See [the rule of 5/3/0](https://en.cppreference.com/w/cpp/language/rule_of_three)

Signed-off-by: Will Killian <william.killian@nextsilicon.com>